### PR TITLE
add missing handle_info for shutdown messages

### DIFF
--- a/lib/oban/met/cronitor.ex
+++ b/lib/oban/met/cronitor.ex
@@ -112,6 +112,10 @@ defmodule Oban.Met.Cronitor do
     {:noreply, %State{state | crontabs: crontabs}}
   end
 
+  def handle_info({:EXIT, _pid, :shutdown}, state) do
+    {:stop, :shutdown, state}
+  end
+
   # Helpers
 
   defp purge_stale(state) do


### PR DESCRIPTION
fixes:

```
** (FunctionClauseError) no function clause matching in Oban.Met.Cronitor.handle_info/2
lib/oban/met/cronitor.ex:76 Oban.Met.Cronitor.handle_info({:EXIT, #PID<...>, :shutdown}, %Oban.Met.Cronitor{...})	
gen_server.erl:1095 :gen_server.try_handle_info/3	
gen_server.erl:1183 :gen_server.handle_msg/6	
proc_lib.erl:241 :proc_lib.init_p_do_apply/3
```

This error has been happening every time we do a rolling deploy.

It happens because `Oban.Met.Cronitor` has the `trap_exit` Process flag set to true, so shutdown exit signals are transformed into a process message

- https://www.erlang.org/doc/apps/erts/erlang.html#exit/2